### PR TITLE
Optimize grapheme split method

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,27 @@
+var {performance} = require("perf_hooks");
+var split = require("./index");
+
+// when a Javascript engine notices a function being called frequently,
+// it will pass it through the optimizer. For consistency, we'd like to make
+// sure that happens before we start measuring.
+for (let i = 0; i < 1000; i++) {
+	split("warm up");
+}
+
+// benchmark a simple string, with no unicode combining characters
+const simpleStart = performance.now();
+for (let i = 0; i < 10000; i++) {
+	split("hello world");
+}
+const simpleEnd = performance.now();
+
+console.log(`simple string: ${simpleEnd - simpleStart}ms`);
+
+// benchmark a complex string with several unicode combining characters
+const complexStart = performance.now();
+for (let i = 0; i < 10000; i++) {
+	split('Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞');
+}
+const complexEnd = performance.now();
+
+console.log(`complex string: ${complexEnd - complexStart}ms`);

--- a/index.js
+++ b/index.js
@@ -110,13 +110,22 @@ function nextGraphemeClusterSize(ts, start) {
 module.exports = function split(str) {
   const graphemeClusters = []
 
-  const codePoints = [...str].map(x => x.codePointAt(0))
-  const ts = codePoints.map(c => typeTrie.get(c) | extPict.get(c))
-  for (let offset = 0; offset < codePoints.length;) {
+  const map = [0]
+  const ts = []
+  for (let i = 0; i < str.length;) {
+    const code = str.codePointAt(i)
+    ts.push(typeTrie.get(code) | extPict.get(code))
+    i += code > 65535 ? 2 : 1
+    map.push(i)
+  }
+  
+  for (let offset = 0; offset < ts.length;) {
     const size = nextGraphemeClusterSize(ts, offset)
-    const graphemeCluster = codePoints.slice(offset, offset + size)
-    graphemeClusters.push(String.fromCodePoint(...graphemeCluster))
+    const start = map[offset]
+	const end = map[offset + size]
+    graphemeClusters.push(str.slice(start, end))
     offset += size
   }
+
   return graphemeClusters
 }


### PR DESCRIPTION
I have an app with a dictionary of several thousand words I want to preprocess. At current, this library is the fastest and most correct grapheme splitter I've found on npm, but I still was interested in seeing if we could get it to a speed where a user wouldn't notice any lag when my app preprocesses all the words. I managed to cut runtime (tested on a list of 8000 words, containing various amounts of conjoining unicode) down to roughly a quarter using a few optimizations in the outermost split method.

The first optimization I employed was to avoid the unnecessary allocation of a new array that isn't ultimately used. `[...str].map` allocated and filled a new array with the individual unicode characters, then immediately allocates and fills another array with the characters mapped to code points and discards the first array. I switched this to a `for(const char of str) codePoints.push(char.codePointAt(0) ...` to avoid the cost of the extra array allocation. 

The next optimization I found was to avoid the round trip between `codePointAt` and `fromCodePoint`. By keeping track of a map (from codePoint indices to original string indices), I could simply call `str.split` and pass the mapped indices to get a substring, and skip the translation and concatenation in `fromCodePoint`.

A last optimization I was able to find was switching from `for..of` to the `while (i < str.length)` you see in the final code. To avoid requesting the computation of each codePoint twice (once during iteration, and then once more in `codePointAt(0)`), I changed the loop to call `str.codePointAt(i)`. I could keep track of the size of each unicode character by determining whether the codePoint was > 65535 (0b1111111111111111).

Again, all told this brought preprocessing times down to ~25% what they were before. I hope these optimizations meet you well.